### PR TITLE
Send params in the request body instead of query string

### DIFF
--- a/lib/tumblr/request.rb
+++ b/lib/tumblr/request.rb
@@ -9,13 +9,13 @@ class Tumblr
     
     # a POST request to http://www.tumblr.com/api/write
     def self.write(options = {})
-      response = HTTParty.post('http://www.tumblr.com/api/write', :query => options)
+      response = HTTParty.post('http://www.tumblr.com/api/write', :body => options)
       return(response) unless raise_errors(response)
     end
     
     # a POST request to http://www.tumblr.com/api/delete
     def self.delete(options = {})
-      response = HTTParty.post('http://www.tumblr.com/api/delete', :query => options)
+      response = HTTParty.post('http://www.tumblr.com/api/delete', :body => options)
       return(response) unless raise_errors(response)
     end
     


### PR DESCRIPTION
Hey

Look like we have some changes in the Tumblr API b/c they require params in the POST body for create/update/delete requests.

In the HTTParty you use query attribute for setting params, right way is to use body key in this case.
Please take a look at this patch.

Thanks,
Timur
