### PR TITLE
API Down Bug

### DIFF
--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -22,7 +22,11 @@ class Tumblr
         #puts response['tumblr']['posts'].to_yaml
         #puts "*****"
       end
-      response['tumblr']['posts']['total'].to_i
+      begin
+        response['tumblr']['posts']['total'].to_i
+      rescue
+        0
+      end
       
     end
 


### PR DESCRIPTION
I've noticed that the tumblr api is down a lot and when it is the response returned in nil which causes a NoMethodError because it's trying to access an array element on nil in the count method of Post. I've added a resque block to return 0 when tumblr api is down and a response isn't returned so that an exception isn't thrown.
